### PR TITLE
Laravel 13 support

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.2, 8.3, 8.4]
+        php: [8.2, 8.3, 8.4, 8.5]
         laravel: ['12.*', '13.*']
         dependency-version: [prefer-lowest, prefer-stable]
         include:

--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -14,15 +14,18 @@ jobs:
     strategy:
       matrix:
         php: [8.2, 8.3, 8.4]
-        laravel: ['11.*', '12.*']
+        laravel: ['12.*', '13.*']
         dependency-version: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 11.*
-            testbench: 9.*
-            phpunit: 10.*
           - laravel: 12.*
             testbench: 10.*
             phpunit: 11.*
+          - laravel: 13.*
+            testbench: 11.*
+            phpunit: 12.*
+        exclude:
+          - php: 8.2
+            laravel: '13.*'
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ use Square1\LaravelIdempotency\Http\Middleware\IdempotencyMiddleware;
 })
 ```
 
-The `append` function here will add this middleware to the end of the global middlewares in your application. For more on handling middleware ordering in Laravel 12, please see [the docs](https://laravel.com/docs/12.x/middleware#global-middleware).
+The `append` function here will add this middleware to the end of the global middlewares in your application. For more on handling middleware ordering in Laravel 12, please see [the docs](https://laravel.com/docs/13.x/middleware#global-middleware).
 
 
 This will run the middleware on all of the routes in the application. However, the `enforced_verbs` value in the package configuration will control whether the middleware has any impact on a given route (by default the middleware won't interfere with GET or HEAD requests).
@@ -127,7 +127,7 @@ This will run the middleware on all of the routes in the application. However, t
 ### Specific Routes
 Alternatively, it can be targeted to specific routes.
 
-You may append the middleware to all api routes, taking advantage of Laravel's [default middleware groups](https://laravel.com/docs/11.x/middleware#laravels-default-middleware-groups):
+You may append the middleware to all api routes, taking advantage of Laravel's [default middleware groups](https://laravel.com/docs/13.x/middleware#laravels-default-middleware-groups):
 
 ``` php
 // bootstrap/app.php
@@ -173,6 +173,7 @@ With the release of Laravel 12 support, the package versioning scheme changed to
 
 | Package Version | Laravel Version(s) |
 |-----------------|--------------------|
+| 13.*            | 13, 12             |
 | 12.*            | 12, 11             |
 | 2.0.0           | 11, 10, 9          |
 | 1.*             | 10,9               |

--- a/composer.json
+++ b/composer.json
@@ -28,12 +28,12 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/support": "^10.0|^11.0|^12.0"
+        "illuminate/support": "^12.0|^13.0"
     },
     "require-dev": {
-        "laravel/framework": "^11.0|^12.0",
-        "phpunit/phpunit": "^10.0|^11.0",
-        "orchestra/testbench": "^9.0|^10.0",
+        "laravel/framework": "^12.0|^13.0",
+        "phpunit/phpunit": "^11.0|^12.0",
+        "orchestra/testbench": "^10.0|^11.0",
         "laravel/pint": "^1.14"
     },
     "scripts": {

--- a/src/Http/Middleware/IdempotencyMiddleware.php
+++ b/src/Http/Middleware/IdempotencyMiddleware.php
@@ -128,46 +128,38 @@ class IdempotencyMiddleware
     {
         $cachedValue = Cache::get($cacheKey);
 
-        if (! $cachedValue instanceof CachedResponseValue) {
-            if (is_array($cachedValue)) {
-                try {
-                    // Check for essential keys before attempting construction
-                    $requiredKeys = ['body', 'status', 'headers', 'path', 'originalKey'];
-                    foreach ($requiredKeys as $key) {
-                        if (! array_key_exists($key, $cachedValue)) {
-                            throw new CorruptedCacheDataException(__("Legacy cached array is missing key: {$key}"));
-                        }
-                    }
-                    $cachedValue = new CachedResponseValue(
-                        $cachedValue['body'],
-                        $cachedValue['status'],
-                        $cachedValue['headers'],
-                        $cachedValue['path'],
-                        $cachedValue['originalKey']
-                    );
-                } catch (CorruptedCacheDataException $e) {
-                    throw $e;
-                }
-            } else {
-                // If it's not an array and not a CachedResponseValue, it's unexpected.
-                throw new CorruptedCacheDataException(__('Unexpected cache payload found. Expected CachedResponseValue or legacy array.'));
+        if (! is_array($cachedValue)) {
+            throw new CorruptedCacheDataException(__('Unexpected cache payload found. Expected array.'));
+        }
+
+        // Validate that all required keys are present
+        $requiredKeys = ['body', 'status', 'headers', 'path', 'originalKey'];
+        foreach ($requiredKeys as $key) {
+            if (! array_key_exists($key, $cachedValue)) {
+                throw new CorruptedCacheDataException(__("Cached array is missing key: {$key}"));
             }
         }
-        // By this point, $cachedValue is guaranteed to be a valid CachedResponseValue object
-        // because the constructor would have thrown an exception if validation failed.
 
-        if ($request->path() != $cachedValue->path) {
-            throw new MismatchedPathException(__('Idempotency key previously used on different route ('.$cachedValue->path.').'));
+        // Construct a validated response object from the cached array
+        $cached = new CachedResponseValue(
+            $cachedValue['body'],
+            $cachedValue['status'],
+            $cachedValue['headers'],
+            $cachedValue['path'],
+            $cachedValue['originalKey']
+        );
+
+        if ($request->path() != $cached->path) {
+            throw new MismatchedPathException(__('Idempotency key previously used on different route ('.$cached->path.').'));
         }
 
-        // Config option to throw exception on duplicate?
         if (config('idempotency.on_duplicate_behaviour') == DuplicateBehaviour::EXCEPTION->value) {
             throw new DuplicateRequestException(__('Duplicate request detected.'));
         }
 
-        return response($cachedValue->body, $cachedValue->status)
-            ->withHeaders($cachedValue->headers)
-            ->header('Idempotency-Relayed', $cachedValue->originalKey);
+        return response($cached->body, $cached->status)
+            ->withHeaders($cached->headers)
+            ->header('Idempotency-Relayed', $cached->originalKey);
     }
 
     /**

--- a/src/Http/Middleware/IdempotencyMiddleware.php
+++ b/src/Http/Middleware/IdempotencyMiddleware.php
@@ -113,13 +113,13 @@ class IdempotencyMiddleware
     {
         $response = $next($request);
 
-        Cache::put($cacheKey, new CachedResponseValue(
-            $response->getContent(),
-            $response->getStatusCode(),
-            $response->headers->all(),
-            $request->path(),
-            $request->header(config('idempotency.idempotency_header')),
-        ), config('idempotency.cache_duration'));
+        Cache::put($cacheKey, [
+            'body' => $response->getContent(),
+            'status' => $response->getStatusCode(),
+            'headers' => $response->headers->all(),
+            'path' => $request->path(),
+            'originalKey' => $request->header(config('idempotency.idempotency_header')),
+        ], config('idempotency.cache_duration'));
 
         return $response;
     }

--- a/src/Http/Middleware/IdempotencyMiddleware.php
+++ b/src/Http/Middleware/IdempotencyMiddleware.php
@@ -128,26 +128,28 @@ class IdempotencyMiddleware
     {
         $cachedValue = Cache::get($cacheKey);
 
-        if (! is_array($cachedValue)) {
+        // Support CachedResponseValue objects still in cache from prior package versions
+        if ($cachedValue instanceof CachedResponseValue) {
+            $cached = $cachedValue;
+        } elseif (is_array($cachedValue)) {
+            // Validate that all required keys are present
+            $requiredKeys = ['body', 'status', 'headers', 'path', 'originalKey'];
+            foreach ($requiredKeys as $key) {
+                if (! array_key_exists($key, $cachedValue)) {
+                    throw new CorruptedCacheDataException(__("Cached array is missing key: {$key}"));
+                }
+            }
+
+            $cached = new CachedResponseValue(
+                $cachedValue['body'],
+                $cachedValue['status'],
+                $cachedValue['headers'],
+                $cachedValue['path'],
+                $cachedValue['originalKey']
+            );
+        } else {
             throw new CorruptedCacheDataException(__('Unexpected cache payload found. Expected array.'));
         }
-
-        // Validate that all required keys are present
-        $requiredKeys = ['body', 'status', 'headers', 'path', 'originalKey'];
-        foreach ($requiredKeys as $key) {
-            if (! array_key_exists($key, $cachedValue)) {
-                throw new CorruptedCacheDataException(__("Cached array is missing key: {$key}"));
-            }
-        }
-
-        // Construct a validated response object from the cached array
-        $cached = new CachedResponseValue(
-            $cachedValue['body'],
-            $cachedValue['status'],
-            $cachedValue['headers'],
-            $cachedValue['path'],
-            $cachedValue['originalKey']
-        );
 
         if ($request->path() != $cached->path) {
             throw new MismatchedPathException(__('Idempotency key previously used on different route ('.$cached->path.').'));

--- a/tests/Feature/MiddlewareTest.php
+++ b/tests/Feature/MiddlewareTest.php
@@ -296,6 +296,33 @@ class MiddlewareTest extends TestCase
     }
 
     #[Test]
+    public function it_handles_cached_object_from_prior_package_version()
+    {
+        $user = $this->getUnguardedUser();
+        $this->actingAs($user);
+        $key = 'object-cache-key';
+        $cacheKey = 'idempotency:'.$user->id.':'.$key;
+
+        // Simulate a CachedResponseValue object left in cache from a prior package version
+        $cachedObject = new \Square1\LaravelIdempotency\Providers\CachedResponseValue(
+            json_encode(['message' => 'Hello from object cache']),
+            Response::HTTP_OK,
+            ['x-custom-header' => ['object_value']],
+            'user',
+            $key,
+        );
+
+        Cache::put($cacheKey, $cachedObject, config('idempotency.cache_duration'));
+
+        $response = $this->post('/user', ['field' => 'test'], ['Idempotency-Key' => $key]);
+
+        $response->assertStatus(Response::HTTP_OK)
+            ->assertJson(['message' => 'Hello from object cache'])
+            ->assertHeader('x-custom-header', 'object_value')
+            ->assertHeader('Idempotency-Relayed', $key);
+    }
+
+    #[Test]
     public function it_handles_array_cache_format_successfully()
     {
         $user = $this->getUnguardedUser();

--- a/tests/Feature/MiddlewareTest.php
+++ b/tests/Feature/MiddlewareTest.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Facades\Cache;
 use Mockery;
 use PHPUnit\Framework\Attributes\Test;
 use Illuminate\Http\Request;
-use Square1\LaravelIdempotency\Providers\CachedResponseValue;
 use Square1\LaravelIdempotency\Tests\TestCase;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -83,7 +82,12 @@ class MiddlewareTest extends TestCase
         $this->assertTrue(Cache::has($cacheKey));
 
         $cachedEntry = Cache::get($cacheKey);
-        $this->assertInstanceOf(CachedResponseValue::class, $cachedEntry);
+        $this->assertIsArray($cachedEntry);
+        $this->assertArrayHasKey('body', $cachedEntry);
+        $this->assertArrayHasKey('status', $cachedEntry);
+        $this->assertArrayHasKey('headers', $cachedEntry);
+        $this->assertArrayHasKey('path', $cachedEntry);
+        $this->assertArrayHasKey('originalKey', $cachedEntry);
     }
 
     #[Test]
@@ -164,7 +168,8 @@ class MiddlewareTest extends TestCase
         $this->assertTrue(Cache::has($cacheKey));
 
         $cachedEntry = Cache::get($cacheKey);
-        $this->assertInstanceOf(CachedResponseValue::class, $cachedEntry);
+        $this->assertIsArray($cachedEntry);
+        $this->assertArrayHasKey('body', $cachedEntry);
     }
 
     #[Test]
@@ -216,13 +221,13 @@ class MiddlewareTest extends TestCase
         $lockKey = 'lock:'.$cacheKey;
 
         // Response that gets populated after first cache check failure
-        $cacheResponse = new CachedResponseValue(
-            '{"status":"Hello"}',
-            200,
-            ['Header' => 'Hi'],
-            'account',
-            $key,
-        );
+        $cacheResponse = [
+            'body' => '{"status":"Hello"}',
+            'status' => 200,
+            'headers' => ['Header' => 'Hi'],
+            'path' => 'account',
+            'originalKey' => $key,
+        ];
 
         $lockMock = Mockery::mock();
         $lockMock->shouldReceive('get')

--- a/tests/Feature/MiddlewareTest.php
+++ b/tests/Feature/MiddlewareTest.php
@@ -296,45 +296,45 @@ class MiddlewareTest extends TestCase
     }
 
     #[Test]
-    public function it_handles_legacy_array_cache_format_successfully()
+    public function it_handles_array_cache_format_successfully()
     {
         $user = $this->getUnguardedUser();
         $this->actingAs($user);
-        $key = 'legacy-array-key';
+        $key = 'array-key';
         $cacheKey = 'idempotency:'.$user->id.':'.$key;
 
-        $legacyCachedData = [
-            'body' => json_encode(['message' => 'Hello from legacy cache']),
+        $cachedData = [
+            'body' => json_encode(['message' => 'Hello from cache']),
             'status' => Response::HTTP_OK,
             'headers' => ['x-custom-header' => ['legacy_value']],
             'path' => 'user',
             'originalKey' => $key,
         ];
 
-        Cache::put($cacheKey, $legacyCachedData, config('idempotency.cache_duration'));
+        Cache::put($cacheKey, $cachedData, config('idempotency.cache_duration'));
 
         $response = $this->post('/user', ['field' => 'test'], ['Idempotency-Key' => $key]);
 
         $response->assertStatus(Response::HTTP_OK)
-            ->assertJson(['message' => 'Hello from legacy cache'])
+            ->assertJson(['message' => 'Hello from cache'])
             ->assertHeader('x-custom-header', 'legacy_value')
             ->assertHeader('Idempotency-Relayed', $key);
     }
 
     #[Test]
-    public function it_handles_legacy_array_with_missing_keys()
+    public function it_handles_array_with_missing_keys()
     {
         $user = $this->getUnguardedUser();
         $this->actingAs($user);
-        $key = 'legacy-missing-keys';
+        $key = 'missing-keys';
         $cacheKey = 'idempotency:'.$user->id.':'.$key;
 
-        $legacyCachedData = [
-            'body' => json_encode(['message' => 'Hello from legacy cache']),
-            // Missing 'status', 'headers', 'path', 'originalKey'
+        $cachedData = [
+            'body' => json_encode(['message' => 'Hello from cache']),
+            // Missing required keys: 'status', 'headers', 'path', 'originalKey'
         ];
 
-        Cache::put($cacheKey, $legacyCachedData, config('idempotency.cache_duration'));
+        Cache::put($cacheKey, $cachedData, config('idempotency.cache_duration'));
 
         $this->post('/user', ['field' => 'test'], ['Idempotency-Key' => $key])
             ->assertStatus(Response::HTTP_BAD_REQUEST)
@@ -342,22 +342,22 @@ class MiddlewareTest extends TestCase
     }
 
     #[Test]
-    public function it_handles_legacy_array_with_invalid_status()
+    public function it_handles_array_with_invalid_status()
     {
         $user = $this->getUnguardedUser();
         $this->actingAs($user);
-        $key = 'legacy-invalid-status';
+        $key = 'invalid-status';
         $cacheKey = 'idempotency:'.$user->id.':'.$key;
 
-        $legacyCachedData = [
-            'body' => json_encode(['message' => 'Hello from legacy cache']),
+        $cachedData = [
+            'body' => json_encode(['message' => 'Hello from cache']),
             'status' => -1, // Invalid status
             'headers' => ['x-custom-header' => ['legacy_value']],
             'path' => 'user',
             'originalKey' => $key,
         ];
 
-        Cache::put($cacheKey, $legacyCachedData, config('idempotency.cache_duration'));
+        Cache::put($cacheKey, $cachedData, config('idempotency.cache_duration'));
 
         $this->post('/user', ['field' => 'test'], ['Idempotency-Key' => $key])
             ->assertStatus(Response::HTTP_BAD_REQUEST)
@@ -365,22 +365,22 @@ class MiddlewareTest extends TestCase
     }
 
     #[Test]
-    public function it_handles_legacy_array_with_empty_path()
+    public function it_handles_array_with_empty_path()
     {
         $user = $this->getUnguardedUser();
         $this->actingAs($user);
-        $key = 'legacy-empty-path';
+        $key = 'empty-path';
         $cacheKey = 'idempotency:'.$user->id.':'.$key;
 
-        $legacyCachedData = [
-            'body' => json_encode(['message' => 'Hello from legacy cache']),
+        $cachedData = [
+            'body' => json_encode(['message' => 'Hello from cache']),
             'status' => Response::HTTP_OK,
             'headers' => ['x-custom-header' => ['legacy_value']],
             'path' => '', // Empty path
             'originalKey' => $key,
         ];
 
-        Cache::put($cacheKey, $legacyCachedData, config('idempotency.cache_duration'));
+        Cache::put($cacheKey, $cachedData, config('idempotency.cache_duration'));
 
         $this->post('/user', ['field' => 'test'], ['Idempotency-Key' => $key])
             ->assertStatus(Response::HTTP_BAD_REQUEST)


### PR DESCRIPTION
Add Laravel 13 support

* Main change is changing our cached response value class back to an array, to stay in line with https://laravel.com/docs/13.x/upgrade#cache-serializable_classes-configuration
* Drops Laravel 11 support, now it has been end-of-life'd